### PR TITLE
Allow user to set limit for media items

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,13 @@ Once you have a profile, you may call the `getInstagramAuthUrl()` method on it t
 
 ### Getting the feed
 
+`Profile::feed($limit = 20)`
+
 Once you have an authenticated profile, you may call the `feed()` method on that profile. The first time the method is called the feed will be fetched from Instagram and it will the be cached forever. Consequent calls to the `feed()` method will simply fetch from the cache. The `feed()` method can be safely called without worrying about exceptions and errors, if something goes wrong, you will just receive an empty collection.
+
+##### Setting limits, and cache
+
+You can set the limit for the returned media items by passing your limit to the feed method. So if you want a limit of 66, you would do: `$profile->feed(66)`. The accepted range is 1 to 100. Once your feed has been fetched, it will be cached, and this result is what will be returned when future calls to the feed methods are made. This means if you want to increase your limit, for example to 88, you will have to call `$profile->refreshFeed(88)`
 
 The feed will be a Laravel collection of items that have the following structure:
 
@@ -104,6 +110,8 @@ The feed will be a Laravel collection of items that have the following structure
 ```
 
 ### Updating the feed
+
+`Profile::refreshFeed($limit = 20)`
 
 Obviously the feed needs to be updated, which is exactly what the `refreshFeed()` method on a Profile instance does. This method will return the same kind of collection as the `feed()` method if successful. However, this method will throw an Exception if one happens to occur (network failure, invalid token, etc).
 

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -76,9 +76,8 @@ class Instagram
         return $this->http->get($url);
     }
 
-    public function fetchMedia(AccessToken $token)
+    public function fetchMedia(AccessToken $token, $limit = 20)
     {
-        $limit = 20;
         $url = sprintf(self::MEDIA_URL_FORMAT, $token->user_id, self::MEDIA_FIELDS, $limit, $token->access_code);
 
         try {

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -87,7 +87,7 @@ class Profile extends Model
         $this->tokens->each->delete();
     }
 
-    public function feed()
+    public function feed($limit = 20)
     {
         if(!$this->latestToken()) {
             return collect([]);
@@ -99,7 +99,7 @@ class Profile extends Model
         $instagram = app()->make(Instagram::class);
 
         try {
-            $feed = $instagram->fetchMedia($this->latestToken());
+            $feed = $instagram->fetchMedia($this->latestToken(), $limit);
             Cache::forever($this->cacheKey(), $feed);
 
             return collect($feed);
@@ -108,10 +108,10 @@ class Profile extends Model
         }
     }
 
-    public function refreshFeed()
+    public function refreshFeed($limit = 20)
     {
         $instagram = app()->make(Instagram::class);
-        $new_feed = $instagram->fetchMedia($this->latestToken());
+        $new_feed = $instagram->fetchMedia($this->latestToken(), $limit);
 
         Cache::forget($this->cacheKey());
         Cache::forever($this->cacheKey(), $new_feed);

--- a/tests/Instagram/InstagramTest.php
+++ b/tests/Instagram/InstagramTest.php
@@ -151,7 +151,7 @@ class InstagramTest extends TestCase
         $profile = Profile::create(['username' => 'test user']);
         $token = AccessToken::createFromResponseArray($profile, $this->validUserWithToken());
 
-        $expected_url = "https://graph.instagram.com/{$token->user_id}/media?fields=caption,id,media_type,media_url,thumbnail_url,children.media_type,children.media_url&limit=20&access_token={$token->access_code}";
+        $expected_url = "https://graph.instagram.com/{$token->user_id}/media?fields=caption,id,media_type,media_url,thumbnail_url,children.media_type,children.media_url&limit=88&access_token={$token->access_code}";
 
         $mockClient = $this->createMock(SimpleClient::class);
         $mockClient->expects($this->once())
@@ -162,7 +162,7 @@ class InstagramTest extends TestCase
         app()->instance(SimpleClient::class, $mockClient);
         $instagram = app(Instagram::class);
 
-        $feed = $instagram->fetchMedia($token);
+        $feed = $instagram->fetchMedia($token, $limit = 88);
 
         $expected = [
             [

--- a/tests/Profiles/ProfilesTest.php
+++ b/tests/Profiles/ProfilesTest.php
@@ -245,17 +245,19 @@ class ProfilesTest extends TestCase
         $mockCLient = $this->createMock(SimpleClient::class);
         $mockCLient->expects($this->once())
                    ->method('get')
-                   ->with($this->equalTo($this->makeMediaUrl($token)))
+                   ->with($this->equalTo($this->makeMediaUrl($token, 33)))
                    ->willReturn($this->exampleMediaResponse());
 
         $this->app->bind(SimpleClient::class, function () use ($mockCLient) {
             return $mockCLient;
         });
 
-        $feed = $profile->feed();
+        $feed = $profile->feed($limit = 33);
 
         $this->assertCount(4, $feed);
     }
+
+
 
     /**
      *@test
@@ -336,14 +338,14 @@ class ProfilesTest extends TestCase
         $mockClient = $this->createMock(SimpleClient::class);
         $mockClient->expects($this->once())
                    ->method('get')
-                   ->with($this->equalTo($this->makeMediaUrl($token)))
+                   ->with($this->equalTo($this->makeMediaUrl($token, 44)))
                    ->willReturn($this->exampleMediaResponse());
 
         $this->app->bind(SimpleClient::class, function () use ($mockClient) {
             return $mockClient;
         });
 
-        $feed = $profile->refreshFeed();
+        $feed = $profile->refreshFeed($limit = 44);
         $this->assertCount(4, $feed);
         $this->assertEquals($feed->all(), cache()->get($profile->cacheKey()));
     }
@@ -437,9 +439,8 @@ class ProfilesTest extends TestCase
         $this->assertEquals($expected, $profile->viewData());
     }
 
-    private function makeMediaUrl($token)
+    private function makeMediaUrl($token, $limit = 20)
     {
-        $limit = 20;
         return sprintf(Instagram::MEDIA_URL_FORMAT, $token->user_id, Instagram::MEDIA_FIELDS, $limit, $token->access_code);
     }
 }


### PR DESCRIPTION
Currently the limit for the fetched media items is hard-coded to twenty. We need to change that so that the user may specify the limit they require (max is 100)

One thing that needs to be decided on is how should caching and limits work. Say I request my latest 20 items, those will be cached and the cached results returned every time I ask for my Profile's feed. So what should happen if I ask for my feed, but with the limit of 30? Options are either just return cached version, or (preferably?) clear cache and fetch latest 30.