### PR TITLE
Bug Fixes & Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,13 @@ return [
      * will become the first image in the carousel, and if there are no images, then
      * the entire carousel will be ignored.
      */
-        'ignore_video' => false,
+     'ignore_video' => false,
+
+    /*
+     * You may set an email address below if you wish to be notified of errors when
+     * attempting to refresh the Instagram feed.
+     */
+    'notify_on_error' => null,
 ];
 ```
 
@@ -105,7 +111,8 @@ The feed will be a Laravel collection of items that have the following structure
     'type' => 'image' // can be either image or video
     'url' => 'source url for media',
     'id' => 'the media id',
-    'cation' => 'the media caption'
+    'caption' => 'the media caption',
+    'permalink' => 'the permalink for accessing the post'
 ]
 ```
 

--- a/config/instagram-feed.php
+++ b/config/instagram-feed.php
@@ -38,4 +38,10 @@ return [
      * the entire carousel will be ignored.
      */
     'ignore_video' => false,
+
+    /*
+     * You may set an email address below if you wish to be notified of errors when
+     * attempting to refresh the Instagram feed.
+     */
+    'notify_on_error' => null,
 ];

--- a/src/Commands/RefreshAuthorizedFeeds.php
+++ b/src/Commands/RefreshAuthorizedFeeds.php
@@ -27,9 +27,12 @@ class RefreshAuthorizedFeeds extends Command
                 if ($e instanceof BadTokenException) {
                     $profile->clearToken();
                 }
-                Mail::to(
-                    config('instagram-feed.notify_on_error'))->send(new FeedRefreshFailed($profile->fresh(), $e->getMessage())
-                );
+
+                if(config('instagram-feed.notify_on_error', null) != 'null') {
+                    Mail::to(
+                        config('instagram-feed.notify_on_error'))->send(new FeedRefreshFailed($profile->fresh(), $e->getMessage())
+                    );
+                }
             }
         });
     }

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -14,7 +14,7 @@ class Instagram
     const EXCHANGE_TOKEN_FORMAT = "https://graph.instagram.com/access_token?grant_type=ig_exchange_token&client_secret=%s&access_token=%s";
     const REFRESH_TOKEN_FORMAT = "https://graph.instagram.com/refresh_access_token?grant_type=ig_refresh_token&access_token=%s";
     const MEDIA_URL_FORMAT = "https://graph.instagram.com/%s/media?fields=%s&limit=%s&access_token=%s";
-    const MEDIA_FIELDS = "caption,id,media_type,media_url,thumbnail_url,children.media_type,children.media_url";
+    const MEDIA_FIELDS = "caption,id,media_type,media_url,thumbnail_url,permalink,children.media_type,children.media_url";
 
 
     private $client_id;

--- a/src/MediaParser.php
+++ b/src/MediaParser.php
@@ -29,7 +29,8 @@ class MediaParser
             'type' => 'image',
             'url'  => $media['media_url'],
             'id' => $media['id'],
-            'caption' => (array_key_exists('caption', $media) ? $media['caption'] : NULL)
+            'caption' => (array_key_exists('caption', $media) ? $media['caption'] : NULL),
+            'permalink' => $media['permalink']
         ];
 
     }
@@ -44,7 +45,8 @@ class MediaParser
             'type' => 'video',
             'url'  => $media['media_url'],
             'id' => $media['id'],
-            'caption' => (array_key_exists('caption', $media) ? $media['caption'] : NULL)
+            'caption' => (array_key_exists('caption', $media) ? $media['caption'] : NULL),
+            'permalink' => $media['permalink']
         ];
     }
 
@@ -59,7 +61,8 @@ class MediaParser
             'type' => strtolower($use['media_type']),
             'url'  => $use['media_url'],
             'id' => $media['id'],
-            'caption' => (array_key_exists('caption', $media) ? $media['caption'] : NULL)
+            'caption' => (array_key_exists('caption', $media) ? $media['caption'] : NULL),
+            'permalink' => $media['permalink']
         ];
     }
 

--- a/src/MediaParser.php
+++ b/src/MediaParser.php
@@ -29,7 +29,7 @@ class MediaParser
             'type' => 'image',
             'url'  => $media['media_url'],
             'id' => $media['id'],
-            'caption' => $media['caption'],
+            'caption' => (array_key_exists('caption', $media) ? $media['caption'] : NULL)
         ];
 
     }
@@ -44,7 +44,7 @@ class MediaParser
             'type' => 'video',
             'url'  => $media['media_url'],
             'id' => $media['id'],
-            'caption' => $media['caption'],
+            'caption' => (array_key_exists('caption', $media) ? $media['caption'] : NULL)
         ];
     }
 
@@ -59,7 +59,7 @@ class MediaParser
             'type' => strtolower($use['media_type']),
             'url'  => $use['media_url'],
             'id' => $media['id'],
-            'caption' => $media['caption']
+            'caption' => (array_key_exists('caption', $media) ? $media['caption'] : NULL)
         ];
     }
 

--- a/tests/Instagram/InstagramTest.php
+++ b/tests/Instagram/InstagramTest.php
@@ -151,7 +151,7 @@ class InstagramTest extends TestCase
         $profile = Profile::create(['username' => 'test user']);
         $token = AccessToken::createFromResponseArray($profile, $this->validUserWithToken());
 
-        $expected_url = "https://graph.instagram.com/{$token->user_id}/media?fields=caption,id,media_type,media_url,thumbnail_url,children.media_type,children.media_url&limit=88&access_token={$token->access_code}";
+        $expected_url = "https://graph.instagram.com/{$token->user_id}/media?fields=caption,id,media_type,media_url,thumbnail_url,permalink,children.media_type,children.media_url&limit=88&access_token={$token->access_code}";
 
         $mockClient = $this->createMock(SimpleClient::class);
         $mockClient->expects($this->once())
@@ -169,25 +169,29 @@ class InstagramTest extends TestCase
                 'type' => 'image',
                 'url' => 'https://scontent.xx.fbcdn.net/v/t51.2885-15/88377911_489796465235615_7665986482865453688_n.jpg?_nc_cat=103&_nc_sid=8ae9d6&_nc_ohc=yrRAJXdvYI4AX9FZA2-&_nc_ht=scontent.xx&oh=8f5c3ce9f043abfb31fc8b21aefc433e&oe=5E93D95F',
                 'caption' => "test caption one",
-                'id' => '17853951361863258'
+                'id' => '17853951361863258',
+                'permalink' => 'https://www.instagram.com/p/Ab12CDeFgHi/',
             ],
             [
                 'type' => 'image',
                 'url' => 'https://scontent.xx.fbcdn.net/v/t51.2885-15/80549905_2594006480669195_8926697910974014198_n.jpg?_nc_cat=104&_nc_sid=8ae9d6&_nc_ohc=vLLm_GgfP60AX8td-AL&_nc_ht=scontent.xx&oh=96a59075b998f800c3b1321a6d87b90c&oe=5E915974',
                 'id' => '18046738186210442',
                 'caption' => "test caption two",
+                'permalink' => 'https://www.instagram.com/p/Ab12CDeFgHi/',
             ],
             [
                 'type' => 'video',
                 'url' => 'https://video.xx.fbcdn.net/v/t50.2886-16/80075364_501004160505270_3520263354313331489_n.mp4?_nc_cat=104&_nc_sid=8ae9d6&_nc_ohc=fXXNJuZcyXEAX8rD8l8&_nc_ht=video.xx&oh=e1cbd15a0f23db1f7d5a5f6ddd2ace83&oe=5E9400C7',
                 'id' => '18068269231170160',
-                'caption' => "test caption three"
+                'caption' => "test caption three",
+                'permalink' => 'https://www.instagram.com/p/Ab12CDeFgHi/',
             ],
             [
                 'type' => 'video',
                 'url' => 'https://video.xx.fbcdn.net/v/t50.2886-16/79391351_481629065798947_3744187809422239413_n.mp4?_nc_cat=102&vs=18083652679083225_3607239704&_nc_vs=HBkcFQAYJEdIZHF1d1FqWldFQkNyWUJBTFhtOWFENUJ2WXpia1lMQUFBRhUAACgAGAAbAYgHdXNlX29pbAExFQAAGAAWsrTUvY%2B%2Fn0AVAigCQzMsF0Ay90vGp%2B%2BeGBJkYXNoX2Jhc2VsaW5lXzFfdjERAHXqBwA%3D&_nc_sid=59939d&efg=eyJ2ZW5jb2RlX3RhZyI6InZ0c192b2RfdXJsZ2VuLjcyMGZlZWQifQ%3D%3D&_nc_ohc=fO8GgEnZ468AX_Fk0Ib&_nc_ht=video.xx&oh=1731b5b44ac7a430e1f90596c15806c3&oe=5E916311&_nc_rid=d477a9015c',
                 'id' => '18033634498224799',
-                'caption' => "test caption four"
+                'caption' => "test caption four",
+                'permalink' => 'https://www.instagram.com/p/Ab12CDeFgHi/',
             ]
         ];
 

--- a/tests/basic_display_media_response_200.json
+++ b/tests/basic_display_media_response_200.json
@@ -5,6 +5,7 @@
       "media_type": "CAROUSEL_ALBUM",
       "media_url": "https://scontent.xx.fbcdn.net/v/t51.2885-15/88377911_489796465235615_7665986482865453688_n.jpg?_nc_cat=103&_nc_sid=8ae9d6&_nc_ohc=yrRAJXdvYI4AX9FZA2-&_nc_ht=scontent.xx&oh=8f5c3ce9f043abfb31fc8b21aefc433e&oe=5E93D95F",
       "caption": "test caption one",
+      "permalink": "https://www.instagram.com/p/Ab12CDeFgHi/",
       "children": {
         "data": [
           {
@@ -64,13 +65,15 @@
       "id": "18046738186210442",
       "media_type": "IMAGE",
       "media_url": "https://scontent.xx.fbcdn.net/v/t51.2885-15/80549905_2594006480669195_8926697910974014198_n.jpg?_nc_cat=104&_nc_sid=8ae9d6&_nc_ohc=vLLm_GgfP60AX8td-AL&_nc_ht=scontent.xx&oh=96a59075b998f800c3b1321a6d87b90c&oe=5E915974",
-      "caption": "test caption two"
+      "caption": "test caption two",
+      "permalink": "https://www.instagram.com/p/Ab12CDeFgHi/",
     },
     {
       "id": "18068269231170160",
       "media_type": "CAROUSEL_ALBUM",
       "media_url": "https://scontent.xx.fbcdn.net/v/t51.2885-15/75379844_677766436086270_517056674519429621_n.jpg?_nc_cat=111&_nc_sid=8ae9d6&_nc_ohc=WK63rO7uo9EAX-qraXd&_nc_ht=scontent.xx&oh=5461ea780615118815c1ac9ecb8029d6&oe=5E91E5D1",
       "caption": "test caption three",
+      "permalink": "https://www.instagram.com/p/Ab12CDeFgHi/",
       "children": {
         "data": [
           {
@@ -106,7 +109,8 @@
       "media_type": "VIDEO",
       "media_url": "https://video.xx.fbcdn.net/v/t50.2886-16/79391351_481629065798947_3744187809422239413_n.mp4?_nc_cat=102&vs=18083652679083225_3607239704&_nc_vs=HBkcFQAYJEdIZHF1d1FqWldFQkNyWUJBTFhtOWFENUJ2WXpia1lMQUFBRhUAACgAGAAbAYgHdXNlX29pbAExFQAAGAAWsrTUvY\u00252B\u00252Fn0AVAigCQzMsF0Ay90vGp\u00252B\u00252BeGBJkYXNoX2Jhc2VsaW5lXzFfdjERAHXqBwA\u00253D&_nc_sid=59939d&efg=eyJ2ZW5jb2RlX3RhZyI6InZ0c192b2RfdXJsZ2VuLjcyMGZlZWQifQ\u00253D\u00253D&_nc_ohc=fO8GgEnZ468AX_Fk0Ib&_nc_ht=video.xx&oh=1731b5b44ac7a430e1f90596c15806c3&oe=5E916311&_nc_rid=d477a9015c",
       "caption": "test caption four",
-      "thumbnail_url": "https://scontent.xx.fbcdn.net/v/t51.2885-15/79129220_127781772008163_6289896098224492554_n.jpg?_nc_cat=104&_nc_sid=8ae9d6&_nc_ohc=ViJh35MyvBwAX-j7zq5&_nc_ht=scontent.xx&oh=759ed307d3f575f6cd59ea2ce59529bd&oe=5E91EFA1"
+      "thumbnail_url": "https://scontent.xx.fbcdn.net/v/t51.2885-15/79129220_127781772008163_6289896098224492554_n.jpg?_nc_cat=104&_nc_sid=8ae9d6&_nc_ohc=ViJh35MyvBwAX-j7zq5&_nc_ht=scontent.xx&oh=759ed307d3f575f6cd59ea2ce59529bd&oe=5E91EFA1",
+      "permalink": "https://www.instagram.com/p/Ab12CDeFgHi/"
     }
   ],
   "paging": {


### PR DESCRIPTION
* Adding notify_on_error to config/instagram-feed.php with a default value of null.
* Updating the README.md file to correct a spelling mistake and to also improving accuracy based on the latest changes.
* Updating src/Instagram.php to include 'permalink' in the list of MEDIA_FIELDS
* Updating src/MediaParser.php to allow optional 'caption' field. If caption is not set with the Instagram post, it simply does not exist. Fixes Posts without a caption cause the feed refresh to fail #6 
* Updating src/MediaParser.php to include 'permalink' field. This can be used in hyperlinks to show the post in its entirety on Instagram.
* Updating src/Commands/RefreshAuthorizedFeeds.php to only send an email if the config entry 'instagram-feed.notify_on_error' is set and is also not null. Fixes Trying to get property 'email' of non-object #7 
* Updating tests to include new permalink field. 