### PR TITLE
Fix table name on rollback

### DIFF
--- a/database/migrations/create_instagram_basic_profile_table.php.stub
+++ b/database/migrations/create_instagram_basic_profile_table.php.stub
@@ -22,6 +22,6 @@ class CreateInstagramBasicProfileTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('dymantic_instagram_basic_profile');
+        Schema::dropIfExists('dymantic_instagram_basic_profiles');
     }
 }


### PR DESCRIPTION
Should be the created table name same as [line 24](https://github.com/Dymantic/laravel-instagram-feed/compare/master...spoyntersmith:patch-1#diff-26002689b9a0d899497b40e1fc83075487143d2a046dab46bd9bcc61e6bb9b06R14)