### PR TITLE
Update MediaParser.php

### DIFF
--- a/src/MediaParser.php
+++ b/src/MediaParser.php
@@ -59,6 +59,10 @@ class MediaParser
             ->first(function ($child) use ($ignore_video) {
                 return $child['media_type'] === 'IMAGE' || (!$ignore_video);
             });
+        
+        if (!$use) {
+            return;
+        }
 
         return [
             'type' => strtolower($use['media_type']),


### PR DESCRIPTION
Fixes an issue on PHP 7.4 where parseAsCarousel would return `$use = null` when a (carousel) post only contains videos and `$ignore_video` is set to true.