### PR TITLE
Added the possibility to ignore the default routes.

### DIFF
--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -166,8 +166,6 @@ class Instagram
 
     /**
      * Configure Instagram Feed to not register its routes.
-     *
-     * @return static
      */
     public static function ignoreRoutes()
     {

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -23,6 +23,13 @@ class Instagram
     private $client_secret;
     private $redirect_uri;
 
+    /**
+     * Indicates if Instagram Feed routes will be registered.
+     *
+     * @var bool
+     */
+    public static $registersRoutes = true;
+
     public function __construct($config)
     {
         $this->client_id = $config["client_id"];
@@ -155,5 +162,15 @@ class Instagram
     {
         $max = $limit ?? 1000;
         return ($previous_response['paging']['next'] ?? false) && ($current_count <= $max);
+    }
+
+    /**
+     * Configure Instagram Feed to not register its routes.
+     *
+     * @return static
+     */
+    public static function ignoreRoutes()
+    {
+        static::$registersRoutes = false;
     }
 }

--- a/src/InstagramFeedServiceProvider.php
+++ b/src/InstagramFeedServiceProvider.php
@@ -43,7 +43,9 @@ class InstagramFeedServiceProvider extends ServiceProvider
             ], 'migrations');
         }
 
-        $this->loadRoutesFrom(__DIR__.'/routes.php');
+        if (Instagram::$registersRoutes) {
+            $this->loadRoutesFrom(__DIR__.'/routes.php');
+        }
 
         $this->loadViewsFrom(__DIR__.'/../views', 'instagram-feed');
 


### PR DESCRIPTION
This PR provides the ability to ignore the default route registered by the instagram service provider. This allows us to override the handleRedirect method in the AccessTokenController class.

Since the registersRoutes variable is static, we can simply disallow the Instagram service provider from binding its routes by using the following method before the instagram service provider is called, e. g. within the app service provider using "Instagram::ignoreRoutes()".