### PR TITLE
Laravel 10 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
   "require": {
     "php": "^8.0",
     "ext-json": "*",
-    "illuminate/config": "^7.0 | ^8.0 | ^9.0",
-    "illuminate/console": "^7.0 | ^8.0 | ^9.0",
-    "illuminate/database": "^7.0 | ^8.0 | ^9.0",
-    "illuminate/http": "^7.0 | ^8.0 | ^9.0",
-    "illuminate/mail": "^7.0 | ^8.0 | ^9.0",
-    "illuminate/support": "^7.0 | ^8.0 | ^9.0",
+    "illuminate/config": "^7.0 | ^8.0 | ^9.0 | ^10.0",
+    "illuminate/console": "^7.0 | ^8.0 | ^9.0 | ^10.0",
+    "illuminate/database": "^7.0 | ^8.0 | ^9.0 | ^10.0",
+    "illuminate/http": "^7.0 | ^8.0 | ^9.0 | ^10.0",
+    "illuminate/mail": "^7.0 | ^8.0 | ^9.0 | ^10.0",
+    "illuminate/support": "^7.0 | ^8.0 | ^9.0 | ^10.0",
     "guzzlehttp/guzzle": "^7.0.1"
   },
   "require-dev": {

--- a/src/Instagram.php
+++ b/src/Instagram.php
@@ -94,7 +94,7 @@ class Instagram
         $url = sprintf(
             self::MEDIA_URL_FORMAT,
             $token->user_id,
-            self::MEDIA_FIELDS,
+            urlencode(self::MEDIA_FIELDS),
             $this->getPageSize($limit),
             $token->access_code
         );


### PR DESCRIPTION
Adds Laravel 10 support.

Also adds `urlencode` for MEDIA_FIELDS in `Instagram::fetchMedia`. Without it the children in the response had only an `id` field - `media_type` and `media_url` were missing.